### PR TITLE
WebcalController: Estimate event duration by parsing Tempo and Level

### DIFF
--- a/MeetUpPlanner/Server/Controllers/WebcalController.cs
+++ b/MeetUpPlanner/Server/Controllers/WebcalController.cs
@@ -66,8 +66,7 @@ namespace MeetUpPlanner.Server.Controllers
                     Summary = meetUp.Title,
                     Description = description.ToString(),
                     Start = new CalDateTime(meetUp.StartDate),
-                    // Ends 1 hours later.
-                    End = new CalDateTime(meetUp.StartDate.AddHours(1.0)),
+                    End = new CalDateTime(meetUp.StartDate.AddHours(meetUp.GetEstimatedDurationInHours())),
                     Location = meetUp.Place
                 };
                 webCal.Events.Add(icalEvent);


### PR DESCRIPTION
This tries to parse distance and tempo from the relevant event properties.

The code parses tempo by matching against the first number with 1..3 digits. To guard against unexpected inputs, it clamps the result between 0 and 100km/h.

Distance is parsed by taking the first 2..4 decimals, optionally followed by 'km'. Result is clamped between 0 and 9999km.

`CalendarItem.GetEstimatedDurationInHours` calculates the expected duration based on distance and tempo. If distance is unknown, it defaults to 50km; if tempo is unknown it defaults to 25km/h. Result is clamped between 0.25 and 24 (15min to 24h).

WebcalController is modified to set the iCal event's end based on the estimated duration.

I expect this code to return quite usable results. Worst case is a calendar entry that is either way too short (minimum 15min) or too long (maximum 24h). If nothing about an event is known, 2h is estimated.

Please note that I don't have a development environment for the MUP right now. The code was written in isolation and copied into this project - I may have missed an import or introduced a typo. 

Please let me know if there's anything wrong. Feel free to add (or request) changes etc. Feel free to run auto-formatting too...